### PR TITLE
Improve hwloc

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1229,6 +1229,13 @@ pocl_set_buffer_image_limits(cl_device_id device)
       device->max_constant_buffer_size = s;
     }
 
+  /* The OpenCL spec requires a minimum value of 32 KiB. */
+  if (device->local_mem_size < 32UL * 1024)
+    device->local_mem_size = 32UL * 1024;
+  /* The OpenCL spec requires a minimum value of 64 KiB. */
+  if (device->max_constant_buffer_size < 64UL * 1024)
+    device->max_constant_buffer_size = 64UL * 1024;
+
   /* We don't have hardware limitations on the buffer-backed image sizes,
    * so we set the maximum size in terms of the maximum amount of pixels
    * that fix in max_mem_alloc_size. A single pixel can take up to 4 32-bit channels,

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1218,17 +1218,6 @@ pocl_set_buffer_image_limits(cl_device_id device)
   assert (device->max_compute_units > 0);
   assert (device->max_mem_alloc_size > 0);
 
-  /* these should be ideally setup by hwloc or proc/cpuinfo;
-   * if not, set them to some reasonable values
-   */
-  if (device->local_mem_size == 0)
-    {
-      cl_ulong s = pocl_size_ceil2_64 (device->global_mem_size / 1024);
-      s = min (s, 512UL * 1024);
-      device->local_mem_size = s;
-      device->max_constant_buffer_size = s;
-    }
-
   /* The OpenCL spec requires a minimum value of 32 KiB. */
   if (device->local_mem_size < 32UL * 1024)
     device->local_mem_size = 32UL * 1024;


### PR DESCRIPTION
[draft]

Taking the discussion following my comment <!-- https://github.com/pocl/pocl/issues/810#issuecomment-723087435 --> in Issue 810 into account, I hereby propose an improved hwloc detection mechanism. With Hyper-Threading enabled, the size of the cache used as local memory will now be divided by the number of PUs (=hardware threads) below it. The proposed code also covers edge cases where all or none of the detected cache levels are shared.

PoCL currently uses L3/L2 for global_mem_cache_size/local_mem_size. As identified by Oblomov<!-- https://github.com/pocl/pocl/issues/810#issuecomment-729505001 -->, Intel uses L2/L1 while AMD (fglrx) uses L1/L1. Hence, I included [commit-hash] to change PoCL's strategy from L3/L2 to L2/L1 (without identifying performance implications). Please let me know in case you prefer the L3/L2 over L2/L1 and I will remove the commit from this PR. The table below shows the resulting values for two example CPUs with Hyper-Threading enabled/disabled and the two proposed strategies.

| CPU (#Cores/#Threads) |  L1* (I+D) | L2* | L3** | Strategy | global_mem_cache_size | local_mem_size | Tested |
|-------------------------|------------|-----|-----|----------|-------------------------|-----------------|--------|
| i5-7200U (2C/4T) |  32K+32K | 256K | 3M | L3/L2 | 3M | 128K (=L2/2) | yes |
| i5-7200U (2C/2T) |  32K+32K | 256K | 3M | L3/L2 | 3M | 256K |
| i5-7200U (2C/4T) |  32K+32K | 256K | 3M | L2/L1 | 256K | 16K (=L1d/2) | yes |
| i5-7200U (2C/2T) |  32K+32K | 256K | 3M | L2/L1 | 256K | 32K |
| Ryzen 5 3600 (6C/12T) | 32K+32K | 512K | 32M | L3/L2 | 32M | 256K (=L2/2) |
| Ryzen 5 3600 (6C/6T) | 32K+32K | 512K | 32M | L3/L2 | 32M | 512K | yes |
| Ryzen 5 3600 (6C/12T) | 32K+32K | 512K | 32M | L2/L1 | 512K | 16K (=L1d/2) |
| Ryzen 5 3600 (6C/6T) | 32K+32K | 512K | 32M | L2/L1 | 512K | 32K | yes |

---

hwloc cache info available for Ryzen 5 3600?
| | v1.11.9 | v2.1.0 |
|--|--|--|
| yes | tested | |
| no | | tested |

| | HT disabled | HT enabled |
|--|--|--|
| i5-7200U | | tested |
| Ryzen 5 3600 | tested | |